### PR TITLE
Typecasting quantity to float

### DIFF
--- a/src/Moltin/Cart/Item/Line.php
+++ b/src/Moltin/Cart/Item/Line.php
@@ -45,7 +45,7 @@ class Line
         $this->store = $store;
 
         foreach ($item as $key => $value) {
-            if ($key == 'quantity') $value = (int)$value;
+            if ($key == 'quantity') $value = (float)$value;
             $this->data[$key] = $value;
         }
 


### PR DESCRIPTION
I think this is better than casting the quantity to an integer, because the quantity could be something like the weight of an item. Suppose your item is rocks, and someone wants to buy 1.5lbs of rocks... if you cast 1.5 to an integer you'll get 1. when cast to a float, you'll obviously receive the correct quantity of 1.5.
