### PR TITLE
Added call to $store->save() method which triggers saveCart()

### DIFF
--- a/src/Moltin/Cart/Cart.php
+++ b/src/Moltin/Cart/Cart.php
@@ -126,6 +126,7 @@ class Cart
             }
 
         }
+        $this->store->save();
     }
 
     /**

--- a/src/Moltin/Cart/Item.php
+++ b/src/Moltin/Cart/Item.php
@@ -140,6 +140,7 @@ class Item
             $this->data[$key] = $value;
 
         }
+
     }
     
     /**

--- a/src/Moltin/Cart/Storage/Runtime.php
+++ b/src/Moltin/Cart/Storage/Runtime.php
@@ -153,4 +153,14 @@ class Runtime implements \Moltin\Cart\StorageInterface
     {
         return $this->id;
     }
+
+    /**
+     * Save current state of the cart (in case of persistent storage)
+     * 
+     * @return void
+     */
+    public function save()
+    {
+        
+    }
 }


### PR DESCRIPTION
Item updating is not working in laravel-cart due to the fact that there is no call to saveCart() method following update item methods (either in Cart or in Item) which leads to the updates being lost next time Cart __construct() is being called.
Added call to $store->save() method which triggers saveCart() in persistent storage (mainly for laravel-cart) on cart item update (from within Cart model and from Item model). Added an empty public save() method to Runtime storage for reference.