### PR TITLE
Changed moltin/currency packet version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "moltin/tax": "dev-master",
-		"moltin/currency": "dev-master"
+	"moltin/currency": "1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
For those who stayed on PHP 5.3 it is very important that this package points to a specific version of the `moltin/currency` package. Otherwise, error occur during the deployment process. After merge you can tag this version as 1.0.0 and then change dependency package version of the `moltin/currency` to 1.1.0 for support latest version. Thanks!